### PR TITLE
bind: bump to 9.18.16

### DIFF
--- a/net/bind/Makefile
+++ b/net/bind/Makefile
@@ -9,8 +9,8 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=bind
-PKG_VERSION:=9.18.11
-PKG_RELEASE:=2
+PKG_VERSION:=9.18.16
+PKG_RELEASE:=1
 USERID:=bind=57:bind=57
 
 PKG_MAINTAINER:=Noah Meyerhans <frodo@morgul.net>
@@ -22,7 +22,7 @@ PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:= \
 	https://www.mirrorservice.org/sites/ftp.isc.org/isc/bind9/$(PKG_VERSION) \
 	https://ftp.isc.org/isc/bind9/$(PKG_VERSION)
-PKG_HASH:=8ff3352812230cbcbda42df87cad961f94163d3da457c5e4bef8057fd5df2158
+PKG_HASH:=c88234fe07ee75c3c8a9e59152fee64b714643de8e22cf98da3db4d0b57e0775
 
 PKG_FIXUP:=autoreconf
 PKG_REMOVE_FILES:=aclocal.m4 libtool.m4


### PR DESCRIPTION
Fixes CVEs:

- CVE-2023-2828: The overmem cleaning process has been improved, to prevent the cache from significantly exceeding the configured max-cache-size limit.
- CVE-2023-2911: A query that prioritizes stale data over lookup triggers a fetch to refresh the stale data in cache. If the fetch is aborted for exceeding the recursion quota, it was possible for named to enter an infinite callback loop and crash due to stack overflow.

The complete list of changes is available in the upstream release notes at
https://ftp.isc.org/isc/bind9/cur/9.18/doc/arm/html/notes.html#notes-for-bind-9-18-16

Signed-off-by: Noah Meyerhans <frodo@morgul.net>
(cherry picked from commit 9ac79ad46966908d2ceb64c0e0d8a0bff435767a)

Maintainer: me / @\<github-user> (find it by checking history of the package Makefile)
Compile tested: (put here arch, model, OpenWrt version)
Run tested: (put here arch, model, OpenWrt version, tests done)

Description:
