### PR TITLE
adblock: update 4.1.5-11

### DIFF
--- a/net/adblock/Makefile
+++ b/net/adblock/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=adblock
 PKG_VERSION:=4.1.5
-PKG_RELEASE:=10
+PKG_RELEASE:=11
 PKG_LICENSE:=GPL-3.0-or-later
 PKG_MAINTAINER:=Dirk Brenken <dev@brenken.org>
 

--- a/net/adblock/files/adblock.init
+++ b/net/adblock/files/adblock.init
@@ -24,7 +24,7 @@ adb_pidfile="/var/run/adblock.pid"
 
 boot() {
 	: >"${adb_pidfile}"
-	rc_procd start_service "boot"
+	rc_procd start_service
 }
 
 start_service() {


### PR DESCRIPTION
* removed an accidentally commited flag of the upcoming adblock 5.x, this fixes a startup regression without trigger interface

Signed-off-by: Dirk Brenken <dev@brenken.org>
(cherry picked from commit b76f6e1c166d0344f9022d1ca994946414d9d035)

Maintainer: me / @\<github-user> (find it by checking history of the package Makefile)
Compile tested: (put here arch, model, OpenWrt version)
Run tested: (put here arch, model, OpenWrt version, tests done)

Description:
