### PR TITLE
uspot: update to Git HEAD (2025-08-07)

### DIFF
--- a/net/uspot/Makefile
+++ b/net/uspot/Makefile
@@ -8,14 +8,16 @@ PKG_MAINTAINER:=Thibaut VARÈNE <hacks@slashdirt.org>
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/f00b4r0/uspot.git
-PKG_SOURCE_DATE:=2025-01-20
-PKG_SOURCE_VERSION:=644fd6f52a8e7b1a72e0937ad0d4cea8e86186a9
-PKG_MIRROR_HASH:=284513ba40547ce6f05c0eeb6adfdba72c23cb151db8807e5a022b374b39db07
+PKG_SOURCE_DATE:=2025-08-07
+PKG_SOURCE_VERSION:=8599a968877b55b0ce29f37d4b2d78036b257787
+PKG_MIRROR_HASH:=011a42c3ed0ef36f454121da8044959f9481dafd6277a73f4fc2f4b53a54f160
 
 CMAKE_SOURCE_SUBDIR:=src
+PKG_BUILD_DEPENDS:=bpf-headers
 
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/cmake.mk
+include $(INCLUDE_DIR)/bpf.mk
 
 define Package/uspot
   SUBMENU:=Captive Portals
@@ -26,7 +28,8 @@ define Package/uspot
   DEPENDS:=+conntrack \
 	   +libblobmsg-json +liblucihttp-ucode +libradcli +libubox +libubus +libuci \
 	   +uspotfilter \
-	   +ucode +ucode-mod-log +ucode-mod-math +ucode-mod-nl80211 +ucode-mod-rtnl +uhttpd-mod-ucode +ucode-mod-uloop
+	   +ucode +ucode-mod-log +ucode-mod-math +ucode-mod-nl80211 +ucode-mod-rtnl +uhttpd-mod-ucode +ucode-mod-uloop \
+	   +ucode-mod-bpf +ucode-mod-struct +kmod-sched-core +kmod-sched-bpf $(BPF_DEPENDS)
 
 endef
 
@@ -63,7 +66,7 @@ define Package/uspotfilter
   CATEGORY:=Network
   TITLE:=uspot firewall interface
   EXTRA_DEPENDS:=ucode (>= 2023-11-07)
-  DEPENDS:=+conntrack +nftables-json +ucode +ucode-mod-rtnl +ucode-mod-uloop
+  DEPENDS:=+conntrack +nftables-json +ucode +ucode-mod-rtnl +ucode-mod-uloop +ucode-mod-log
   PKGARCH:=all
 endef
 
@@ -72,11 +75,17 @@ define Package/uspotfilter/description
   It is compatible with firewall4.
 endef
 
+define Build/Compile
+	$(call CompileBPF,$(PKG_BUILD_DIR)/src/uspot-bpf.c)
+	$(call Build/Compile/Default,)
+endef
+
 define Package/uspot/install
-	$(INSTALL_DIR) $(1)/usr/bin $(1)/usr/share $(1)/usr/lib/ucode $(1)/etc/init.d $(1)/etc/config
+	$(INSTALL_DIR) $(1)/usr/bin $(1)/usr/share $(1)/usr/lib/ucode $(1)/etc/init.d $(1)/etc/config $(1)/lib/bpf
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/radius-client $(1)/usr/bin/radius-client
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/uspot-das $(1)/usr/bin/uspot-das
 	$(INSTALL_DATA) $(PKG_BUILD_DIR)/libuam.so $(1)/usr/lib/ucode/uam.so
+	$(INSTALL_DATA) $(PKG_BUILD_DIR)/src/uspot-bpf.o $(1)/lib/bpf/uspot.o
 	$(INSTALL_CONF) $(PKG_BUILD_DIR)/files/etc/config/uspot $(1)/etc/config/uspot
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/files/etc/init.d/uspot $(1)/etc/init.d/uspot
 	$(CP) $(PKG_BUILD_DIR)/files/usr/bin $(1)/usr/


### PR DESCRIPTION
e2e3c649ab80 README update
18e6bcc14cc2 uspot/portal: urldecode FORM POST data bf6051dba822 uspot/handler-uam: accept /login endpoint 32273591d8d5 uspotfilter: provide peer_lookup answers only for known clients b0aeef9973a9 README: clarify uam vs radius mode features b7b0d0efb0e2 uspot: improve config documentation
bce68a97fad8 captive: rename to 'uspot'
da6ca713e15d uspot: client_remove(): pass device to ratelimit client_delete() 3ebfe262bfb1 uspot: remove unused radius_call() args 691d73aa00dc uspot: let radius_init() set all required payload members be50a66b777f uspot: allow setting global bandwidth limits 4851ada4b0c0 uspot: send Called-Station-Id in Acct-On/Off requests 0974fc8d47ac Implement uspot-bpf, an eBPF traffic counter e99809f97e34 introduce uspotbpf.uc
7f6f43883568 uspotbpf: work around ucode-mod-bpf bug 319e0c285afb uspot: hook traffic accounting
ccf3fa9b8e83 uspot: client_interim(): remove dead code 0e92cc9f6e75 uspotbpf: fix priority conflict with ratelimit 55d40a8794b6 uspot: implement traffic limiting
b05257e862cb uspot: implement swapio
e83f95081c21 uspot: radius_acct(): don't needlessly call uspotfilter 442cff773220 uspotfilter: cleanup unused API
7878d512cd21 handler-api: include 'seconds-remaining' only if not captive cca6d218a6a7 handler-api: implement 'bytes-remaining' e8cf3d08ac64 uspot: start(): ratelimit clearing is independent from RADIUS accounting 6d12a2da5b20 README update
bf6364cb61ea config: clarify units for acct_interval 8133b8cd215e uspot: implement state_get()/state_set() 094825fdfe68 radius-client: lowercase non-attribute JSON members de70c588c2e3 radius-client: add error reporting
ebe9eac34f5b radius: add option for udp or tcp connection d6b338d5d194 uspot: support RadSec with PSK authentication 53de77512159 uspot: validate config
d0578f740111 uspot: don't store debug data through uspotfilter fe4fa5e8a25f uspot.init: rename DAS instance
bd1fbe481da3 README update
76a03155db44 uspot: add support for secondary RADIUS servers 694ff75f4fcc uspot: remove 'final_redirect_url' config option a347454db08c handler: redirect UAM connected clients to the 'res=already' UAM url 0ea8f9bec545 handlers: simplify auth check
f69e1df8db0f Improve RADIUS error handling and reporting 34216b56b9ed src/CMakeLists: disable -Werror
8599a968877b Makefile: sync with OpenWrt repo

Update Makefile to reflect addition of the eBPF module and other changes in the package


(cherry picked from commit 3d76208)

Maintainer: me / @\<github-user> (find it by checking history of the package Makefile)
Compile tested: (put here arch, model, OpenWrt version)
Run tested: (put here arch, model, OpenWrt version, tests done)

Description:
